### PR TITLE
Add intent filter for stepple dev client scheme

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,6 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "stepple",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
@@ -24,7 +23,17 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "package": "com.anonymous.stepple"
+      "package": "com.anonymous.stepple",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "category": ["BROWSABLE", "DEFAULT"],
+          "data": [
+            { "scheme": "stepple" },
+            { "scheme": "stepple", "host": "expo-development-client" }
+          ]
+        }
+      ]
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
## Summary
- define Android intent filter for `stepple` scheme including `expo-development-client`
- remove duplicate `scheme` entry in app.json

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688fbdbbf73083278dd88698493bcecd