### PR TITLE
refactor: use GoogleFit.isAuthorized

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -36,9 +36,9 @@ export default function TabOneScreen() {
       console.log('Google Fit authorization options', options);
 
       try {
-        const isAuthorized = await GoogleFit.checkIsAuthorized();
-        console.log('checkIsAuthorized ->', isAuthorized);
-        if (!isAuthorized) {
+        await GoogleFit.checkIsAuthorized();
+        console.log('checkIsAuthorized ->', GoogleFit.isAuthorized);
+        if (!GoogleFit.isAuthorized) {
           const authResult = await GoogleFit.authorize(options);
           console.log('authorize() result', authResult);
           if (authResult.success) {


### PR DESCRIPTION
## Summary
- rely on `GoogleFit.isAuthorized` after `checkIsAuthorized`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688fdade93f083278030faae4087234d