### PR TITLE
Add Android activity recognition permission

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,8 +33,9 @@
             { "scheme": "stepple", "host": "expo-development-client" }
           ]
         }
-      ]
-    },
+        ],
+        "permissions": ["ACTIVITY_RECOGNITION"]
+      },
     "web": {
       "bundler": "metro",
       "output": "static",

--- a/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `null`;


### PR DESCRIPTION
## Summary
- enable ACTIVITY_RECOGNITION permission for Android builds
- update StyledText test snapshot

## Testing
- `npx expo prebuild --platform android --clean`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fdadff098832782912107d3514dfd